### PR TITLE
Drop lib/gem-name.rb in favor of lib/gem/name.rb

### DIFF
--- a/lib/manageiq-providers-workflows.rb
+++ b/lib/manageiq-providers-workflows.rb
@@ -1,4 +1,0 @@
-require "manageiq/providers/workflows/engine"
-require "manageiq/providers/workflows/version"
-
-require "manageiq/providers/workflows"

--- a/lib/manageiq/providers/workflows.rb
+++ b/lib/manageiq/providers/workflows.rb
@@ -1,3 +1,6 @@
+require "manageiq/providers/workflows/engine"
+require "manageiq/providers/workflows/version"
+
 module ManageIQ
   module Providers
     module Workflows

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,4 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].sort.each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].sort.each { |f| require f }
 
-require "manageiq-providers-workflows"
+require "manageiq/providers/workflows"


### PR DESCRIPTION
Adopt convention already supported by bundler and required by zeitwerk so we don't need to tell zeitwerk to ignore this lib/gem-name.rb file.