### PR TITLE
Disable :refresh_ems support

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager.rb
@@ -3,6 +3,8 @@ class ManageIQ::Providers::Workflows::AutomationManager < ManageIQ::Providers::E
   require_nested :Workflow
   require_nested :WorkflowInstance
 
+  supports_not :refresh_ems
+
   def self.hostname_required?
     # TODO: ExtManagementSystem is validating this
     false


### PR DESCRIPTION
The Embedded Workflows AutomationManager does not need EmsRefresh for anything and does not support refresh.

Follow-up:
* https://github.com/ManageIQ/manageiq/pull/22458