### PR TITLE
Disable workflow execution if prototype disabled

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -8,6 +8,8 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
   end
 
   def execute(run_by_userid: "admin", inputs: {})
+    raise _("execute is not enabled") unless Settings.prototype.ems_workflows.enabled
+
     require "floe"
     floe = Floe::Workflow.new(payload)
 

--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -1,5 +1,7 @@
 class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
   def run_queue
+    raise _("run_queue is not enabled") unless Settings.prototype.ems_workflows.enabled
+
     queue_opts = {
       :class_name  => self.class.name,
       :instance_id => id,
@@ -38,6 +40,8 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
   end
 
   def run
+    raise _("run is not enabled") unless Settings.prototype.ems_workflows.enabled
+
     creds = credentials&.transform_values do |val|
       ManageIQ::Password.try_decrypt(val)
     end

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
     }
   end
 
+  before { stub_settings_merge(:prototype => {:ems_workflows => {:enabled => true}}) }
+
   describe "#run_queue" do
     it "queues WorkflowInstance#run" do
       workflow_instance.run_queue

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
     }
   end
 
+  before { stub_settings_merge(:prototype => {:ems_workflows => {:enabled => true}}) }
+
   describe "#execute" do
     it "creates the workflow_instance" do
       workflow.execute(:inputs => inputs)


### PR DESCRIPTION
If the ems_workflows prototype flag is disabled then do not allow running workflows