### PR TITLE
Rename `Workflow#execute` to `#run`

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
     create!(:manager => workflows_automation_manager, :name => name, :payload => json.to_json, :payload_type => "json", **kwargs)
   end
 
-  def execute(run_by_userid: "admin", inputs: {})
+  def run(inputs = {}, userid = "system")
     raise _("execute is not enabled") unless Settings.prototype.ems_workflows.enabled
 
     require "floe"
@@ -23,13 +23,13 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
     transaction do
       miq_task = MiqTask.create!(
         :name   => "Execute Workflow",
-        :userid => run_by_userid
+        :userid => userid
       )
 
       instance = children.create!(
         :manager       => manager,
         :type          => "#{manager.class}::WorkflowInstance",
-        :run_by_userid => run_by_userid,
+        :run_by_userid => userid,
         :miq_task      => miq_task,
         :payload       => payload,
         :credentials   => credentials,

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
 
   describe "#execute" do
     it "creates the workflow_instance" do
-      workflow.execute(:inputs => inputs)
+      workflow.run(inputs)
 
       expect(workflow.children.count).to eq(1)
       expect(ems.configuration_scripts.count).to eq(1)
@@ -36,14 +36,14 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
     end
 
     it "returns the task id" do
-      miq_task_id = workflow.execute(:inputs => inputs)
+      miq_task_id = workflow.run(inputs)
       expect(MiqTask.find(miq_task_id)).to have_attributes(
         :name => "Execute Workflow"
       )
     end
 
     it "queues WorkflowInstance#run" do
-      workflow.execute(:inputs => inputs)
+      workflow.run(inputs)
 
       workflow_instance = ems.configuration_scripts.first
 
@@ -58,18 +58,18 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
     end
 
     it "defaults to admin userid" do
-      workflow.execute(:inputs => inputs)
+      workflow.run(inputs)
 
       workflow_instance = ems.configuration_scripts.first
-      expect(workflow_instance.run_by_userid).to eq("admin")
-      expect(workflow_instance.miq_task.userid).to eq("admin")
+      expect(workflow_instance.run_by_userid).to eq("system")
+      expect(workflow_instance.miq_task.userid).to eq("system")
     end
 
     context "with another user" do
       let(:user) { FactoryBot.create(:user) }
 
       it "uses the userid provided" do
-        workflow.execute(:run_by_userid => user.userid)
+        workflow.run({}, user.userid)
 
         workflow_instance = ems.configuration_scripts.first
         expect(workflow_instance.run_by_userid).to eq(user.userid)


### PR DESCRIPTION
Maintain compatibility with `EmbeddedAnsible::Playbook#run`