### PR TITLE
Add ability to pass zone or other role to run

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
     create!(:manager => workflows_automation_manager, :name => name, :payload => JSON.pretty_generate(json), :payload_type => "json", **kwargs)
   end
 
-  def run(inputs = {}, userid = "system")
+  def run(inputs: {}, userid: "system", zone: nil, role: "automation")
     raise _("execute is not enabled") unless Settings.prototype.ems_workflows.enabled
 
     require "floe"
@@ -41,7 +41,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
       miq_task.update!(:context_data => {:workflow_instance_id => instance.id})
     end
 
-    instance.run_queue
+    instance.run_queue(:zone => zone, :role => role)
 
     miq_task.id
   end

--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -1,13 +1,14 @@
 class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
-  def run_queue
+  def run_queue(zone: nil, role: "automation")
     raise _("run_queue is not enabled") unless Settings.prototype.ems_workflows.enabled
 
     queue_opts = {
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "run",
-      :role        => "automate",
-      :args        => [],
+      :role        => role,
+      :zone        => zone,
+      :args        => [{:zone => zone, :role => role}],
     }
 
     if miq_task_id
@@ -40,7 +41,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     end
   end
 
-  def run
+  def run(zone: nil, role: "automation")
     raise _("run is not enabled") unless Settings.prototype.ems_workflows.enabled
 
     creds = credentials&.transform_values do |val|
@@ -85,6 +86,6 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
 
     save!
 
-    run_queue if next_state.present?
+    run_queue(:zone => zone, :role => role) if next_state.present?
   end
 end

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
 
   before { stub_settings_merge(:prototype => {:ems_workflows => {:enabled => true}}) }
 
-  describe "#execute" do
+  describe "#run" do
     it "creates the workflow_instance" do
-      workflow.run(inputs)
+      workflow.run(:inputs => inputs)
 
       expect(workflow.children.count).to eq(1)
       expect(ems.configuration_scripts.count).to eq(1)
@@ -36,14 +36,14 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
     end
 
     it "returns the task id" do
-      miq_task_id = workflow.run(inputs)
+      miq_task_id = workflow.run(:inputs => inputs)
       expect(MiqTask.find(miq_task_id)).to have_attributes(
         :name => "Execute Workflow"
       )
     end
 
     it "queues WorkflowInstance#run" do
-      workflow.run(inputs)
+      workflow.run(:inputs => inputs)
 
       workflow_instance = ems.configuration_scripts.first
 
@@ -58,22 +58,44 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
     end
 
     it "defaults to admin userid" do
-      workflow.run(inputs)
+      workflow.run(:inputs => inputs)
 
       workflow_instance = ems.configuration_scripts.first
       expect(workflow_instance.run_by_userid).to eq("system")
       expect(workflow_instance.miq_task.userid).to eq("system")
     end
 
+    it "defaults to automation role" do
+      workflow.run(:inputs => inputs)
+
+      workflow_instance = ems.configuration_scripts.first
+      queue_item = MiqQueue.find_by(:class_name => workflow_instance.class.name, :method_name => "run")
+
+      expect(queue_item.role).to eq("automation")
+    end
+
     context "with another user" do
       let(:user) { FactoryBot.create(:user) }
 
       it "uses the userid provided" do
-        workflow.run({}, user.userid)
+        workflow.run(:userid => user.userid)
 
         workflow_instance = ems.configuration_scripts.first
         expect(workflow_instance.run_by_userid).to eq(user.userid)
         expect(workflow_instance.miq_task.userid).to eq(user.userid)
+      end
+    end
+
+    context "with a zone" do
+      let(:zone) { FactoryBot.create(:zone) }
+
+      it "uses the provided zone" do
+        workflow.run(:zone => zone.name)
+
+        workflow_instance = ems.configuration_scripts.first
+        queue_item = MiqQueue.find_by(:class_name => workflow_instance.class.name, :method_name => "run")
+
+        expect(queue_item.zone).to eq(zone.name)
       end
     end
   end


### PR DESCRIPTION
Add in the option for passing in an alternate role or a zone for the workflow to be run on.  This is important if access to resources is limited to workers running only on a certain zone.

Core PR:
* https://github.com/ManageIQ/manageiq/pull/22546