### PR TITLE
Allow creation of Credentials for Workflows

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/credential.rb
@@ -2,9 +2,70 @@ class ManageIQ::Providers::Workflows::AutomationManager::Credential < ManageIQ::
   validates :ems_ref, :presence => true, :uniqueness_when_changed => {:scope => [:tenant_id]},
             :format => {:with => /\A[\w\-]+\z/i, :message => N_("may contain only alphanumeric and _ - characters")}
 
-  FRIENDLY_NAME = "Workflows Credential"
+  FRIENDLY_NAME = "Workflows Credential".freeze
+
+  COMMON_ATTRIBUTES = [
+    {
+      :component  => 'text-field',
+      :label      => N_('Name'),
+      :helperText => N_('Name of this credential'),
+      :name       => 'name',
+      :id         => 'name'
+    },
+    {
+      :component  => 'text-field',
+      :label      => N_('Reference'),
+      :helperText => N_('Unique reference for this credential'),
+      :name       => 'ems_ref',
+      :id         => 'ems_ref'
+    },
+    {
+      :component  => 'text-field',
+      :label      => N_('Username'),
+      :helperText => N_('Username for this credential'),
+      :name       => 'userid',
+      :id         => 'userid'
+    },
+    {
+      :component  => 'password-field',
+      :label      => N_('Password'),
+      :helperText => N_('Password for this credential'),
+      :name       => 'password',
+      :id         => 'password',
+      :type       => 'password'
+    },
+    {
+      :component      => 'password-field',
+      :label          => N_('Private key'),
+      :helperText     => N_('RSA or DSA private key to be used instead of password'),
+      :componentClass => 'textarea',
+      :name           => 'auth_key',
+      :id             => 'auth_key',
+      :type           => 'password'
+    },
+    {
+      :component  => 'password-field',
+      :label      => N_('Private key passphrase'),
+      :helperText => N_('Passphrase to unlock SSH private key if encrypted'),
+      :name       => 'auth_key_password',
+      :id         => 'auth_key_password',
+      :maxLength  => 1024,
+      :type       => 'password'
+    }
+  ].freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES
+
+  API_OPTIONS = {
+    :label      => N_('Workflows'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
 
   def self.params_to_attributes(params)
+    allowed_params     = API_ATTRIBUTES.pluck(:id)
+    unpermitted_params = params.keys - allowed_params
+    raise ArgumentError, _("Invalid parameters: %{params}" % {:params => unpermitted_params.join(", ")}) if unpermitted_params.any?
+
     params
   end
 end

--- a/app/models/manageiq/providers/workflows/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/credential.rb
@@ -1,4 +1,10 @@
 class ManageIQ::Providers::Workflows::AutomationManager::Credential < ManageIQ::Providers::EmbeddedAutomationManager::Authentication
   validates :ems_ref, :presence => true, :uniqueness_when_changed => {:scope => [:tenant_id]},
             :format => {:with => /\A[\w\-]+\z/i, :message => N_("may contain only alphanumeric and _ - characters")}
+
+  FRIENDLY_NAME = "Workflows Credential"
+
+  def self.params_to_attributes(params)
+    params
+  end
 end

--- a/spec/models/manageiq/providers/workflows/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/credential_spec.rb
@@ -28,4 +28,23 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Credential do
       )
     end
   end
+
+  describe ".create_in_provider" do
+    let(:params) { {"name" => "My Credential", "ems_ref" => "my-credential", "userid" => "admin", "password" => "1234"} }
+
+    it "creates the credential with the requested params" do
+      expect(described_class.create_in_provider(ems.id, params)).to have_attributes(
+        :manager  => ems,
+        :name     => params["name"],
+        :ems_ref  => params["ems_ref"],
+        :userid   => params["userid"],
+        :password => params["password"]
+      )
+    end
+
+    it "rejects parameters that aren't allowed" do
+      expect { described_class.create_in_provider(ems.id, params.merge("resource" => "something nefarious")) }
+        .to raise_error(ArgumentError, "Invalid parameters: resource")
+    end
+  end
 end


### PR DESCRIPTION
Creating an authentication requires defining `params_to_attributes` https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/embedded_automation_manager/authentication.rb#L28