### PR TITLE
Always allow seeding even without prototype flag

### DIFF
--- a/lib/manageiq/providers/workflows.rb
+++ b/lib/manageiq/providers/workflows.rb
@@ -5,8 +5,6 @@ module ManageIQ
   module Providers
     module Workflows
       def self.seed
-        return unless Settings.prototype.ems_workflows.enabled
-
         # provider = ManageIQ::Providers::Workflows::Provider.in_my_region.first_or_initialize
         # provider.update!(
         #   :name => "Embedded Workflows",


### PR DESCRIPTION
This is in the background if the user hasn't set the prototype flag, so they won't realize it anyway. However, when they do enable the flag they can then hit the ground running without having to wait for a resed.

@agrare Please review.