### PR TITLE
Fix workflow_instance queue delivery

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -47,8 +47,10 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     end
   end
 
-  def run(zone: nil, role: "automation", object_type: nil, object_id: nil)
+  def run(args = {})
     raise _("run is not enabled") unless Settings.prototype.ems_workflows.enabled
+
+    zone, role, object_type, object_id = args.values_at(:zone, :role, :object_type, :object_id)
 
     object = object_type.constantize.find_by(:id => object_id) if object_type && object_id
     object.before_ae_starts({}) if object.present? && object.respond_to?(:before_ae_starts)

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -43,6 +43,9 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
 
         queue_item = MiqQueue.find_by(:class_name => workflow_instance.class.name)
         expect(queue_item.zone).to eq(zone.name)
+
+        queue_item.deliver
+        expect(workflow_instance.reload.status).to eq("success")
       end
     end
 
@@ -52,6 +55,9 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
 
         queue_item = MiqQueue.find_by(:class_name => workflow_instance.class.name)
         expect(queue_item.role).to eq("ems_operations")
+
+        queue_item.deliver
+        expect(workflow_instance.reload.status).to eq("success")
       end
     end
 
@@ -69,6 +75,9 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
             :method_name => :queue_callback
           }
         )
+
+        queue_item.deliver
+        expect(workflow_instance.reload.status).to eq("success")
       end
     end
   end


### PR DESCRIPTION
Fix wrong number of arguments error from using kwargs

```
[----] E, [2023-06-15T11:14:20.330024 #734974:9740] ERROR -- evm: MIQ(MiqQueue#deliver) Message id: [9], Error: [wrong number of arguments (given 1, expected 0)]
[----] E, [2023-06-15T11:14:20.330115 #734974:9740] ERROR -- evm: [ArgumentError]: wrong number of arguments (given 1, expected 0)  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2023-06-15T11:14:20.330170 #734974:9740] ERROR -- evm: /home/grare/adam/src/manageiq/manageiq-providers-workflows/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb:50:in `run'
/home/grare/adam/src/manageiq/manageiq/app/models/miq_queue.rb:499:in `block in dispatch_method'
```