### PR TITLE
Set the Floe::Workflow::Runner based on platform

### DIFF
--- a/config/initializers/floe_docker_runner.rb
+++ b/config/initializers/floe_docker_runner.rb
@@ -1,0 +1,2 @@
+require "floe"
+Floe::Workflow::Runner.docker_runner = ManageIQ::Providers::Workflows::Engine.floe_docker_runner


### PR DESCRIPTION
Set the workflow runner based on the platform we're running on

Depends on:
- [x] https://github.com/ManageIQ/floe/pull/48
- [x] New release of Floe https://github.com/ManageIQ/floe/releases/tag/v0.2.0
- [x] https://github.com/ManageIQ/manageiq/pull/22603