### PR TITLE
Updated Workflows Credential Schema

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/credential.rb
@@ -7,17 +7,12 @@ class ManageIQ::Providers::Workflows::AutomationManager::Credential < ManageIQ::
   COMMON_ATTRIBUTES = [
     {
       :component  => 'text-field',
-      :label      => N_('Name'),
-      :helperText => N_('Name of this credential'),
-      :name       => 'name',
-      :id         => 'name'
-    },
-    {
-      :component  => 'text-field',
       :label      => N_('Reference'),
       :helperText => N_('Unique reference for this credential'),
       :name       => 'ems_ref',
-      :id         => 'ems_ref'
+      :id         => 'ems_ref',
+      :isRequired => true,
+      :validate   => [{:type => "required"}]
     },
     {
       :component  => 'text-field',


### PR DESCRIPTION
Removed the `Name` field from the `ManageIQ::Providers::Workflows::AutomationManager::Credential` type schema since name is a common field across credential types and should be in the front-end. Also added some validation to the `Reference` field since it is a required field.