### PR TITLE
Fix parent class for Workflows ScmCredential

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/scm_credential.rb
@@ -1,3 +1,5 @@
-class ManageIQ::Providers::Workflows::AutomationManager::ScmCredential < ManageIQ::Providers::EmbeddedAutomationManager::ScmCredential
+class ManageIQ::Providers::Workflows::AutomationManager::ScmCredential < ManageIQ::Providers::Workflows::AutomationManager::Authentication
+  include ManageIQ::Providers::EmbeddedAutomationManager::ScmCredentialMixin
+
   FRIENDLY_NAME = "Workflows SCM Credential".freeze
 end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/22577