### PR TITLE
Fix workflows queued on embedded_ansible

### DIFF
--- a/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::ConfigurationS
           :class_name  => described_class.name,
           :method_name => "create_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible",
+          :role        => nil,
           :zone        => nil
         )
       end
@@ -343,7 +343,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::ConfigurationS
           :class_name  => described_class.name,
           :method_name => "update_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible",
+          :role        => nil,
           :zone        => nil
         )
       end
@@ -378,7 +378,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::ConfigurationS
           :class_name  => described_class.name,
           :method_name => "delete_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible",
+          :role        => nil,
           :zone        => nil
         )
       end


### PR DESCRIPTION
depends upon:
- https://github.com/ManageIQ/manageiq/pull/22614


Workflow role is no longer going to embedded ansible

(this makes the build green)

