### PR TITLE
Fix WorkflowInstance#output not being set

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -71,7 +71,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     wf = Floe::Workflow.new(payload, context, creds)
     wf.step
 
-    update!(:context => wf.context.to_h, :status => wf.status)
+    update!(:context => wf.context.to_h, :status => wf.status, :output => wf.output)
 
     object.after_ae_delivery(status) if object.present? && object.respond_to?(:after_ae_delivery)
 

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
   let(:zone)        { EvmSpecHelper.local_miq_server.zone }
   let(:context)     { Floe::Workflow::Context.new(:input => input) }
   let(:credentials) { {} }
-  let(:input)       { {} }
+  let(:input)       { {"foo" => "bar"} }
 
   let(:user)              { FactoryBot.create(:user_with_group) }
   let(:workflow)          { FactoryBot.create(:workflows_automation_workflow, :manager => ems, :payload => payload.to_json, :credentials => credentials) }
@@ -87,6 +87,12 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
       workflow_instance.run
 
       expect(workflow_instance.reload.status).to eq("success")
+    end
+
+    it "sets the workflow output" do
+      workflow_instance.run
+
+      expect(workflow_instance.reload.output).to eq("foo" => "bar")
     end
 
     context "with a zone and role" do


### PR DESCRIPTION
After moving the state run logic into floe we no longer were setting the state output.  This was causing issues when the caller needs the output to populate e.g. a dynamic dialog dropdown.

https://github.com/ManageIQ/manageiq-providers-workflows/pull/5/files#diff-80ee5262679b29c698ee75771be7948fbfe8fcea9ff7c05ee83aaa9273d47885L89