### PR TITLE
Fix the default role from automation to automate

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
     create!(:manager => workflows_automation_manager, :name => name, :payload => JSON.pretty_generate(json), :payload_type => "json", **kwargs)
   end
 
-  def run(inputs: {}, userid: "system", zone: nil, role: "automation", object: nil)
+  def run(inputs: {}, userid: "system", zone: nil, role: "automate", object: nil)
     raise _("execute is not enabled") unless Settings.prototype.ems_workflows.enabled
 
     require "floe"

--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
-  def run_queue(zone: nil, role: "automation", object: nil)
+  def run_queue(zone: nil, role: "automate", object: nil)
     raise _("run_queue is not enabled") unless Settings.prototype.ems_workflows.enabled
 
     args = {:zone => zone, :role => role}

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
@@ -65,13 +65,13 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
       expect(workflow_instance.miq_task.userid).to eq("system")
     end
 
-    it "defaults to automation role" do
+    it "defaults to automate role" do
       workflow.run(:inputs => inputs)
 
       workflow_instance = ems.configuration_scripts.first
       queue_item = MiqQueue.find_by(:class_name => workflow_instance.class.name, :method_name => "run")
 
-      expect(queue_item.role).to eq("automation")
+      expect(queue_item.role).to eq("automate")
     end
 
     context "with another user" do


### PR DESCRIPTION
The correct role name it "automate" not "automation", this was causing queued workflow_instances to not be picked up by Generic Workers