### PR TITLE
Pass manageiq_api url in global context

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -12,6 +12,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
 
     require "floe"
     context = Floe::Workflow::Context.new(:input => inputs)
+    context.execution["_manageiq_api_url"] = MiqRegion.my_region.remote_ws_url
 
     miq_task = instance = nil
     transaction do

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
         :type        => "ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance",
         :payload     => workflow.payload,
         :credentials => workflow.credentials,
-        :context     => {"Execution" => {"Input" => {}}, "State" => {}, "StateMachine" => {}, "StateHistory" => [], "Task" => {}},
+        :context     => {"Execution" => hash_including("Input" => inputs), "State" => {}, "StateMachine" => {}, "StateHistory" => [], "Task" => {}},
         :output      => {},
         :status      => "pending"
       )
@@ -72,6 +72,27 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
       queue_item = MiqQueue.find_by(:class_name => workflow_instance.class.name, :method_name => "run")
 
       expect(queue_item.role).to eq("automate")
+    end
+
+    context "with an active webservices server" do
+      let(:ipaddress) { "1.2.3.4" }
+      let(:hostname)  { "manageiq.localdomain" }
+      let!(:web_server) do
+        FactoryBot.create(
+          :miq_server,
+          :has_active_webservices => true,
+          :hostname               => hostname,
+          :ipaddress              => ipaddress
+        )
+      end
+
+      it "adds remote_ws_url to the context" do
+        workflow.run(:inputs => inputs)
+        workflow_instance = ems.configuration_scripts.first
+
+        expected_api_url = URI::HTTPS.build(:host => ipaddress).to_s
+        expect(workflow_instance.context["Execution"]).to include("_manageiq_api_url" => expected_api_url)
+      end
     end
 
     context "with another user" do


### PR DESCRIPTION
Set the manageiq_api_url in the global context so that it can be referenced by workflows.