### PR TITLE
Update Workflow#credential format

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -56,13 +56,13 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     object.before_ae_starts({}) if object.present? && object.respond_to?(:before_ae_starts)
 
     creds = credentials&.transform_values do |val|
-      if val.start_with?("$.")
-        ems_ref, field = val.match(/^\$\.(?<ems_ref>.+)\.(?<field>.+)$/).named_captures.values_at("ems_ref", "field")
+      if val.kind_of?(Hash)
+        credential_ref, credential_field = val.values_at("credential_ref", "credential_field")
 
-        authentication = parent.authentications.find_by(:ems_ref => ems_ref)
+        authentication = parent.authentications.find_by(:ems_ref => credential_ref)
         raise ActiveRecord::RecordNotFound, "Couldn't find Authentication" if authentication.nil?
 
-        authentication.send(field)
+        authentication.send(credential_field)
       else
         val
       end

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
     end
 
     context "with a Credentials property in the workflow_content" do
-      let(:credentials) { {"username" => "$.my-credential.userid", "password" => "$.my-credential.password"} }
+      let(:credentials) { {"username" => {"credential_ref" => "my-credential", "credential_field" => "userid"}, "password" => {"credential_ref" => "my-credential", "credential_field" => "password"}} }
       let(:payload) do
         {
           "Comment" => "Example Workflow",


### PR DESCRIPTION
Change the Workflow#credentials format for authentication references from JSON path to `{"credential_ref" => "", "credential_field" => ""}`

Ref: https://github.com/ManageIQ/manageiq-api/pull/1231#issuecomment-1662896566