### PR TITLE
Set network=host for development mode

### DIFF
--- a/lib/manageiq/providers/workflows/engine.rb
+++ b/lib/manageiq/providers/workflows/engine.rb
@@ -48,9 +48,13 @@ module ManageIQ
               "ca_cert"    => "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
             )
           elsif MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.supports_command?("podman")
-            Floe::Workflow::Runner::Podman.new
+            options = {}
+            options["network"] = "host" unless Rails.env.production?
+            Floe::Workflow::Runner::Podman.new(options)
           else
-            Floe::Workflow::Runner::Docker.new
+            options = {}
+            options["network"] = "host" unless Rails.env.production?
+            Floe::Workflow::Runner::Docker.new(options)
           end
         end
       end

--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.2.0"
+  spec.add_dependency "floe", "~> 0.3.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
In development or test set the docker network to host to allow access to localhost:3000

Depends on
- [x] https://github.com/ManageIQ/floe/pull/81
- [x] Release of floe