### PR TITLE
Override the podman image storage root directory

### DIFF
--- a/lib/manageiq/providers/workflows/engine.rb
+++ b/lib/manageiq/providers/workflows/engine.rb
@@ -49,7 +49,12 @@ module ManageIQ
             )
           elsif MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.supports_command?("podman")
             options = {}
-            options["network"] = "host" unless Rails.env.production?
+            if Rails.env.production?
+              options["root"] = Rails.root.join("data/containers/storage").to_s
+            else
+              options["network"] = "host"
+            end
+
             Floe::Workflow::Runner::Podman.new(options)
           else
             options = {}


### PR DESCRIPTION
By default non-root images are stored in the home directory of the non-root user.  On appliances as the manageiq user this is a very small partition and not many images can be stored here.

Depends on:
- [x] https://github.com/ManageIQ/floe/pull/90
- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/415

https://github.com/ManageIQ/manageiq/issues/22640