### PR TITLE
Strip trailing .$ from Credentials

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -55,16 +55,16 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     object = object_type.constantize.find_by(:id => object_id) if object_type && object_id
     object.before_ae_starts({}) if object.present? && object.respond_to?(:before_ae_starts)
 
-    creds = credentials&.transform_values do |val|
-      if val.kind_of?(Hash)
+    creds = credentials&.to_h do |key, val|
+      if key.end_with?(".$")
         credential_ref, credential_field = val.values_at("credential_ref", "credential_field")
 
         authentication = parent.authentications.find_by(:ems_ref => credential_ref)
         raise ActiveRecord::RecordNotFound, "Couldn't find Authentication" if authentication.nil?
 
-        authentication.send(credential_field)
+        [key.chomp(".$"), authentication.send(credential_field)]
       else
-        val
+        [key, val]
       end
     end
 

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
     end
 
     context "with a Credentials property in the workflow_content" do
-      let(:credentials) { {"username" => {"credential_ref" => "my-credential", "credential_field" => "userid"}, "password" => {"credential_ref" => "my-credential", "credential_field" => "password"}} }
+      let(:credentials) { {"username.$" => {"credential_ref" => "my-credential", "credential_field" => "userid"}, "password.$" => {"credential_ref" => "my-credential", "credential_field" => "password"}} }
       let(:payload) do
         {
           "Comment" => "Example Workflow",
@@ -134,8 +134,8 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
             "FirstState" => {
               "Type"        => "Succeed",
               "Credentials" => {
-                "username" => "$.username",
-                "password" => "$.password"
+                "username.$" => "$.username",
+                "password.$" => "$.password"
               }
             }
           }


### PR DESCRIPTION
When transforming a payload_template style hash we have to strip off the
trailing .$ after interpolating the value.