### PR TITLE
Bump floe to v0.4.1 for task output fixes

### DIFF
--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.4.0"
+  spec.add_dependency "floe", "~> 0.4.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Pull in floe v0.4.1 for fixes in task output and combined stdout/stderr on podman/docker

https://github.com/ManageIQ/floe/releases/tag/v0.4.1