### PR TITLE
Fix issue where new service account ENV var is forced in every process

### DIFF
--- a/lib/manageiq/providers/workflows/engine.rb
+++ b/lib/manageiq/providers/workflows/engine.rb
@@ -47,7 +47,7 @@ module ManageIQ
               "token_file"           => "/run/secrets/kubernetes.io/serviceaccount/token",
               "ca_cert"              => "/run/secrets/kubernetes.io/serviceaccount/ca.crt",
               "namespace"            => File.read("/run/secrets/kubernetes.io/serviceaccount/namespace"),
-              "task_service_account" => ENV.fetch("AUTOMATION_JOB_SERVICE_ACCOUNT")
+              "task_service_account" => ENV.fetch("AUTOMATION_JOB_SERVICE_ACCOUNT", nil)
             }
 
             Floe::Workflow::Runner::Kubernetes.new(options)


### PR DESCRIPTION
ManageIQ::Providers::Workflows::Engine.floe_docker_runner is called in a config/initializer, which means that it is being executed in every Rails environment on boot. This includes things like `bin/rake evm:deployment_status`, which happens very early on in the orchestrator boot process.

When the orchestrator is on Kubernetes, it starts creating a Floe::Kubernetes::Runner, but then requires the new AUTOMATION_JOB_SERVICE_ACCOUNT, which doesn't exist as it is only meant to exist in the new AutomationWorker. Because of this the orchestrator fails to boot.

This commit allows that value to be nil, so it can move on. However, we should find a way to avoid creating the runner on every boot, which is a better solution.