### PR TITLE
Check if a workflow payload is valid during sync

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/configuration_script_source.rb
@@ -85,18 +85,18 @@ class ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSour
         [nil, err.message]
       end
 
-    return if payload_error
-
     description = floe_workflow&.comment
 
     configuration_script_payloads.find_or_initialize_by(:name => name).tap do |wf|
       wf.update!(
-        :name         => name,
-        :description  => description,
-        :manager_id   => manager_id,
-        :type         => self.class.module_parent::Workflow.name,
-        :payload      => payload,
-        :payload_type => "json"
+        :name          => name,
+        :description   => description,
+        :manager_id    => manager_id,
+        :type          => self.class.module_parent::Workflow.name,
+        :payload       => payload,
+        :payload_type  => "json",
+        :payload_valid => !!floe_workflow,
+        :payload_error => payload_error
       )
     end
   end

--- a/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
@@ -206,18 +206,30 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::ConfigurationS
       context "with workflows with invalid json" do
         let(:repo_dir_structure) { %w[invalid_json.asl] }
 
-        it "skips the invalid workflow file" do
+        it "sets the payload_valid and payload_error attributes" do
           record = build_record
-          expect(record.configuration_script_payloads).to be_empty
+          expect(record.configuration_script_payloads.first).to have_attributes(
+            :name          => "invalid_json.asl",
+            :payload       => "{\"Invalid Json\"\n",
+            :payload_type  => "json",
+            :payload_valid => false,
+            :payload_error => "expected ':' after object key at line 1 column 1"
+          )
         end
       end
 
       context "with workflows with missing states" do
         let(:repo_dir_structure) { %w[missing_states.asl] }
 
-        it "skips the invalid workflow file" do
+        it "sets the payload_valid and payload_error attributes" do
           record = build_record
-          expect(record.configuration_script_payloads).to be_empty
+          expect(record.configuration_script_payloads.first).to have_attributes(
+            :name          => "missing_states.asl",
+            :payload       => "{\"Comment\": \"Missing States\"}\n",
+            :payload_type  => "json",
+            :payload_valid => false,
+            :payload_error => "State Machine does not have required field \"States\""
+          )
         end
       end
 


### PR DESCRIPTION
When syncing a repository and creating workflows check if the payload is valid and if it isn't set a (hopefully) helpful error message.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/710
~~https://github.com/ManageIQ/manageiq-schema/pull/712~~

TODO:
* We don't currently check if a configuration_script_payload "supports" running, we could enable that and check for validity there and use payload_error as the unsupported reason