### PR TITLE
Bump floe for kubernetes image pull error fixes

### DIFF
--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.5.0"
+  spec.add_dependency "floe", "~> 0.6.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Bump floe to v0.6.0 to pull in the fixes for payload verification and ImagePull errors causing hangs on kubernetes.