### PR TITLE
Run apt-get update before install in bin/before_install

### DIFF
--- a/bin/before_install
+++ b/bin/before_install
@@ -2,7 +2,8 @@
 
 if [ -n "$CI" ]; then
   echo "== Installing system packages =="
-  sudo apt-get install libcurl4-openssl-dev
+  sudo apt-get update
+  sudo apt-get install -y libcurl4-openssl-dev
   echo
 fi
 


### PR DESCRIPTION
Fixes issue such as:

```
 After this operation, 1541 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.7
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.7
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.68.0-1ubuntu2.7_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Followup to https://github.com/ManageIQ/manageiq/pull/21843