### PR TITLE
Update `:credentials` column if state sets a new credential

### DIFF
--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.6.0"
+  spec.add_dependency "floe", "~> 0.7.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
If a state sets a new credential then encrypt the value and update the credentials column of the workflow instance.

NOTE: currently this will set a ManageIQ::Password encrypted value in the credentials jsonb column.  If there is an existing "mapped" authentication it will create a new in-line entry in the Credentials column instead of updating the Authentication record.

Documentation:
* https://github.com/ManageIQ/manageiq-documentation/pull/1773

Fix Auth:
* https://github.com/ManageIQ/manageiq/pull/22824