### PR TITLE
Use new Floe.set_runner syntax

### DIFF
--- a/config/initializers/floe_docker_runner.rb
+++ b/config/initializers/floe_docker_runner.rb
@@ -1,2 +1,1 @@
-require "floe"
-Floe::Workflow::Runner.docker_runner = ManageIQ::Providers::Workflows::Engine.floe_docker_runner
+ManageIQ::Providers::Workflows::Engine.set_floe_runner

--- a/lib/manageiq/providers/workflows/engine.rb
+++ b/lib/manageiq/providers/workflows/engine.rb
@@ -34,7 +34,7 @@ module ManageIQ
           %w[ManageIQ::Providers::Workflows]
         end
 
-        def self.floe_docker_runner
+        def self.set_floe_runner
           require "miq_environment"
           require "floe"
 
@@ -52,17 +52,17 @@ module ManageIQ
               "task_service_account" => ENV.fetch("AUTOMATION_JOB_SERVICE_ACCOUNT", nil)
             }.merge(floe_runner_settings.kubernetes)
 
-            Floe::Workflow::Runner::Kubernetes.new(options)
+            Floe.set_runner("docker", "kubernetes", options)
           elsif MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.supports_command?("podman")
             options = {}
             options["root"] = Rails.root.join("data/containers/storage").to_s if Rails.env.production?
             options.merge!(floe_runner_settings.podman)
 
-            Floe::Workflow::Runner::Podman.new(options)
+            Floe.set_runner("docker", "podman", options)
           else
             options = floe_runner_settings.docker.to_hash
 
-            Floe::Workflow::Runner::Docker.new(options)
+            Floe.set_runner("docker", "docker", options)
           end
         end
       end

--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.8.0"
+  spec.add_dependency "floe", "~> 0.9.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
depend upon:
- [x] https://github.com/ManageIQ/floe/pull/152

This removes some knowledge of the internals of floe (but who is kidding who, we still need to know all options that each runner supports)

This also preps us for supporting multiple protocols
