### PR TITLE
Handle the case where `:credentials` column is `nil`

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -100,7 +100,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
   end
 
   def update_credentials!(workflow_credentials)
-    workflow_credentials.each do |key, val|
+    workflow_credentials&.each do |key, val|
       # If the workflow has changed a credential that is mapped to an Authentication record
       # drop the mapping and replace it with an in-line encrypted value
       if credentials.key?("#{key}.$")

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
       expect(workflow_instance.reload.output).to eq("foo" => "bar")
     end
 
+    context "with credentials=nil" do
+      let(:credentials) { nil }
+
+      it "sets the status to success" do
+        workflow_instance.run
+
+        expect(workflow_instance.reload.status).to eq("success")
+      end
+    end
+
     context "with a workflow that sets a credential" do
       let(:payload) do
         {


### PR DESCRIPTION
If the `:credentials` column is `nil` rather than `{}` as we had been testing with, the `resolved_credentials` method properly handles this but the `update_credentials!` method was not and caused the workflow instance run to throw an exception