### PR TITLE
Ensure WorkflowInstance#credentials is not nil

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
         :run_by_userid => userid,
         :miq_task      => miq_task,
         :payload       => payload,
-        :credentials   => credentials,
+        :credentials   => credentials || {},
         :context       => context.to_h,
         :output        => inputs,
         :status        => "pending"

--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -100,10 +100,12 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
   end
 
   def update_credentials!(workflow_credentials)
+    self.credentials ||= {}
+
     workflow_credentials&.each do |key, val|
       # If the workflow has changed a credential that is mapped to an Authentication record
       # drop the mapping and replace it with an in-line encrypted value
-      if credentials.key?("#{key}.$")
+      if credentials&.key?("#{key}.$")
         # If the value is unchanged then we don't need to update anything
         next if resolve_mapped_credential(credentials["#{key}.$"]) == val
 

--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.7.0"
+  spec.add_dependency "floe", "~> 0.7.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -128,6 +128,18 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
         expect(workflow_instance.reload.credentials).to include("Bearer" => expected_value)
       end
 
+      context "with credentials=nil" do
+        let(:credentials) { nil }
+
+        it "sets the status to success" do
+          workflow_instance.run
+
+          expect(workflow_instance.reload.status).to eq("success")
+          expected_value = ManageIQ::Password.encrypt("TOKEN")
+          expect(workflow_instance.reload.credentials).to include("Bearer" => expected_value)
+        end
+      end
+
       context "with an existing value" do
         let(:credentials) { {"Bearer" => "OLD_TOKEN"} }
 


### PR DESCRIPTION
In the case where no credentials are mapped to a workflow, but the workflow sets a credential value the workflow was failing trying to assign a key to `nil`

Related:
* https://github.com/ManageIQ/floe/pull/156