### PR TITLE
Don't pass Config::Options in for Runner settings

### DIFF
--- a/lib/manageiq/providers/workflows/engine.rb
+++ b/lib/manageiq/providers/workflows/engine.rb
@@ -60,7 +60,7 @@ module ManageIQ
 
             Floe::Workflow::Runner::Podman.new(options)
           else
-            options = floe_runner_settings.docker
+            options = floe_runner_settings.docker.to_hash
 
             Floe::Workflow::Runner::Docker.new(options)
           end


### PR DESCRIPTION
Fixes
```
NoMethodError: undefined method `fetch' for #<Config::Options pull_policy="always", network="host">
/home/grare/adam/src/manageiq/manageiq-providers-workflows/lib/manageiq/providers/workflows/engine.rb:65:in `new'
/home/grare/adam/src/manageiq/manageiq-providers-workflows/lib/manageiq/providers/workflows/engine.rb:65:in `floe_docker_runner'
/home/grare/adam/src/manageiq/manageiq-providers-workflows/config/initializers/floe_docker_runner.rb:2:in `<main>'
```

Introduced by https://github.com/ManageIQ/manageiq-providers-workflows/pull/65/files#diff-90ac1f1e5e5d8f5256b8242a1bc5e74907bd131561f2c7d3bd6bf441f32d4859R63