### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager.rb
@@ -1,10 +1,4 @@
 class ManageIQ::Providers::Workflows::AutomationManager < ManageIQ::Providers::EmbeddedAutomationManager
-  require_nested :ConfigurationScriptSource
-  require_nested :Credential
-  require_nested :ScmCredential
-  require_nested :Workflow
-  require_nested :WorkflowInstance
-
   supports_not :refresh_ems
 
   def self.hostname_required?


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854