### PR TITLE
Set workflow description from asl comment

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/configuration_script_source.rb
@@ -76,8 +76,24 @@ class ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSour
   end
 
   def create_workflow_from_payload(name, payload)
+    floe_workflow =
+      begin
+        Floe::Workflow.new(payload)
+      rescue Floe::InvalidWorkflowError
+        nil
+      end
+
+    description = floe_workflow&.comment
+
     configuration_script_payloads.find_or_initialize_by(:name => name).tap do |wf|
-      wf.update!(:name => name, :manager_id => manager_id, :type => self.class.module_parent::Workflow.name, :payload => payload, :payload_type => "json")
+      wf.update!(
+        :name         => name,
+        :description  => description,
+        :manager_id   => manager_id,
+        :type         => self.class.module_parent::Workflow.name,
+        :payload      => payload,
+        :payload_type => "json"
+      )
     end
   end
 end

--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.9.0"
+  spec.add_dependency "floe", "~> 0.10.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::ConfigurationS
 
         expect(record.configuration_script_payloads.first).to have_attributes(
           :name         => "hello_world.asl",
+          :description  => "hello world",
           :payload      => a_string_including("\"Comment\": \"hello world\""),
           :payload_type => "json"
         )

--- a/spec/support/fake_workflows_repo.rb
+++ b/spec/support/fake_workflows_repo.rb
@@ -14,7 +14,7 @@ module Spec
 
       def dummy_workflow_data_for(_filename)
         <<~WORKFLOW_DATA
-          {"Comment": "hello world"}
+          {"Comment": "hello world", "States": {"Start": {"Type": "Succeed"}}, "StartAt": "Start"}
         WORKFLOW_DATA
       end
     end


### PR DESCRIPTION
We do something similar if you manually create a Workflow from a json payload since we don't have a file path, https://github.com/ManageIQ/manageiq-providers-workflows/blob/master/app/models/manageiq/providers/workflows/automation_manager/workflow.rb#L4 and I thought it'd add a nice "human readable" description

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
