### PR TITLE
Workflow#run accepts context

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -7,12 +7,12 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
     create!(:manager => workflows_automation_manager, :name => name, :payload => JSON.pretty_generate(json), :payload_type => "json", **kwargs)
   end
 
-  def run(inputs: {}, userid: "system", zone: nil, role: "automate", object: nil)
+  def run(inputs: {}, userid: "system", zone: nil, role: "automate", object: nil, execution_context: {})
     raise _("execute is not enabled") unless Settings.prototype.ems_workflows.enabled
 
     require "floe"
-    context = Floe::Workflow::Context.new(:input => inputs)
-    context.execution["_manageiq_api_url"] = MiqRegion.my_region.remote_ws_url
+    execution_context = execution_context.merge("_manageiq_api_url" => MiqRegion.my_region.remote_ws_url)
+    context = Floe::Workflow::Context.new({"Execution" => execution_context}, :input => inputs)
 
     miq_task = instance = nil
     transaction do


### PR DESCRIPTION
dependency:
- tag: v0.11.0 (already updated)

pass context into run.
This allows us to pass `_miq_request_task_id` for provisioning (and other) requests

we could probably drop the `role` parameter

Feedback:
- Do we want to set `object.class, object.id`?
