### PR TITLE
Fix BuiltinMethods.email task status spec

### DIFF
--- a/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ManageIQ::Providers::Workflows::BuiltinMethods do
       it "calls GenericMailer" do
         runner_context = described_class.email(params)
         expect(runner_context).to have_key("miq_task_id")
-        expect(MiqTask.find_by(:id => runner_context["miq_task_id"])).to have_attributes(:state => "Queued", :status => "Error")
+        expect(MiqTask.find_by(:id => runner_context["miq_task_id"])).to have_attributes(:state => "Finished", :status => "Error")
       end
     end
   end


### PR DESCRIPTION
We fixed the MiqTask state to be Finished when it fails due to not having a notifier role.

https://github.com/ManageIQ/manageiq/pull/23036

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
