### PR TITLE
automatically update options for provisioning requests

### DIFF
--- a/lib/manageiq/providers/workflows/builtin_methods.rb
+++ b/lib/manageiq/providers/workflows/builtin_methods.rb
@@ -23,6 +23,10 @@ module ManageIQ
           return BuiltinRunnner.error!({}, :cause => "Unable to find MiqReqeustTask id: [#{object_id}]")                        if miq_request_task.nil?
           return BuiltinRunnner.error!({}, :cause => "Calling provision_execute on non-provisioning request: [#{object_type}]") unless miq_request_task.class < ::MiqProvision
 
+          new_options = context.input.symbolize_keys.slice(*miq_request_task.options.keys)
+          miq_request_task.options_will_change!
+          miq_request_task.options.merge!(new_options)
+          miq_request_task.save!
           miq_request_task.execute_queue
 
           {"miq_request_task_id" => miq_request_task.id}


### PR DESCRIPTION
Use input to set options in the provisioning request.
This allows a workflow to manipulate the request.

- We always change the miq_request_task, even when the options have not been updated. Optionally we can add a sync parameter
- For the 2 non symbol keys, we do end up with duplicates (`nil` -> `""`, and the fqname)