### PR TITLE
Rename 'builtin' scheme to 'manageiq'

### DIFF
--- a/lib/manageiq/providers/workflows/builtin_runner.rb
+++ b/lib/manageiq/providers/workflows/builtin_runner.rb
@@ -4,7 +4,7 @@ module ManageIQ
       require "floe"
 
       class BuiltinRunnner < Floe::Runner
-        SCHEME = "builtin".freeze
+        SCHEME = "manageiq".freeze
         SCHEME_PREFIX = "#{SCHEME}://".freeze
 
         class << self

--- a/spec/lib/manageiq/providers/workflows/builtin_runner_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/builtin_runner_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ManageIQ::Providers::Workflows::BuiltinRunnner do
     end
 
     it "with an invalid method" do
-      result = subject.run_async!("builtin://invalid_method")
+      result = subject.run_async!("manageiq://invalid_method")
       expect(result).to include(
         "running" => false,
         "success" => false,


### PR DESCRIPTION
Built on #95 

@agrare As discussed this renames the builtin scheme to manageiq.  cc @kbrock

Co-dependent on
- [ ] https://github.com/ManageIQ/manageiq-content/pull/748