### PR TITLE
Add event driven workflows runner

### DIFF
--- a/lib/manageiq/providers/workflows/engine.rb
+++ b/lib/manageiq/providers/workflows/engine.rb
@@ -37,6 +37,10 @@ module ManageIQ
           ]
         end
 
+        def self.automation_runners
+          [ManageIQ::Providers::Workflows::Runner]
+        end
+
         def self.floe_runner_name
           if (runner_setting = Settings.ems.ems_workflows.runner.presence)
             runner_setting

--- a/lib/manageiq/providers/workflows/runner.rb
+++ b/lib/manageiq/providers/workflows/runner.rb
@@ -1,0 +1,86 @@
+module ManageIQ
+  module Providers
+    module Workflows
+      class Runner
+        include Vmdb::Logging
+
+        class << self
+          def runner
+            @runner ||= new.tap(&:start)
+          end
+        end
+
+        attr_reader :workflows
+
+        def initialize
+          require "floe"
+          require "concurrent/hash"
+
+          @workflows          = Concurrent::Hash.new
+          @docker_wait_thread = nil
+        end
+
+        def start
+          $workflows_log.debug("Runner: Starting workflows runner...")
+          self.docker_wait_thread = Thread.new { docker_wait }
+          $workflows_log.debug("Runner: Starting workflows runner...Complete")
+        end
+
+        def stop
+          $workflows_log.debug("Runner: Stopping workflows runner...")
+          stop_thread(docker_wait_thread)
+
+          self.docker_wait_thread = nil
+          $workflows_log.debug("Runner: Stopping workflows runner...Complete")
+        end
+
+        def add_workflow(workflow, queue_args)
+          workflows[workflow.id] ||= [workflow, queue_args]
+        end
+
+        def delete_workflow(workflow)
+          workflows.delete(workflow.id)
+        end
+
+        private
+
+        attr_accessor :docker_wait_thread
+
+        def docker_wait
+          loop do
+            docker_runner = Floe::Runner.for_resource("docker")
+            docker_runner.wait do |event, runner_context|
+              $workflows_log.info("Runner: Caught event [#{event}] for container [#{runner_context["container_ref"]}]")
+
+              workflow, queue_args = workflow_by_runner_context(runner_context)
+              next if workflow.nil?
+
+              $workflows_log.info("Runner: Queueing update for WorkflowInstance ID: [#{workflow.id}]")
+
+              workflow.run_queue(**queue_args)
+            end
+          rescue => err
+            $workflows_log.warn("Error: [#{err}]")
+            $workflows_log.log_backtrace(err)
+          end
+        end
+
+        def stop_thread(thread)
+          return if thread.nil?
+
+          thread.kill
+          thread.join(0)
+        end
+
+        def workflow_by_runner_context(runner_context)
+          workflows.detect do |_id, (workflow, _queue_args)|
+            context       = workflow.reload.context
+            container_ref = context.dig("State", "RunnerContext", "container_ref")
+
+            container_ref == runner_context["container_ref"]
+          end&.last
+        end
+      end
+    end
+  end
+end

--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.13.0"
+  spec.add_dependency "floe", "~> 0.13.0", ">= 0.13.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/lib/manageiq/providers/workflows/runner_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/runner_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe ManageIQ::Providers::Workflows::Runner do
+  require "floe"
+
+  let(:subject)  { described_class.new }
+  let(:workflow) { FactoryBot.create(:workflows_automation_workflow_instance) }
+  let(:queue_args) { {:role => "automate"} }
+
+  describe ".add_workflow" do
+    it "adds the workflow to the workflows hash" do
+      subject.add_workflow(workflow, queue_args)
+      expect(subject.workflows.count).to eq(1)
+      expect(subject.workflows[workflow.id]).to eq([workflow, queue_args])
+    end
+  end
+
+  describe ".delete_workflow" do
+    context "with nothing in #workflows" do
+      it "doesn't throw an exception" do
+        expect(subject.delete_workflow(workflow)).to be_nil
+      end
+    end
+
+    context "with a workflow in #workflows" do
+      before { subject.add_workflow(workflow, queue_args) }
+
+      it "deletes the workflow from #workflows" do
+        subject.delete_workflow(workflow)
+        expect(subject.workflows).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a Workflows::Runner class which keeps a persistent thread waiting for events from Floe.  Once an event is raised we try to link the event up to a workflow and we queue a step action if we find one.

If a workflow isn't found for example if it is already completed and removed from the list then we simply continue without queueing anything.

It is common to get multiple events for a single container run so this isn't a perfect "queue step when ready" and can be more efficient but currently this is erring on the side of caution (check step_ready on every event).

Also if the worker goes down and is restarted for any reason, the typical timer-based step is still on the queue and the running workflow will be added to the runner on the next timed check.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23151
- [x] https://github.com/ManageIQ/floe/pull/265

Fixes https://github.com/ManageIQ/manageiq-providers-workflows/issues/109
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
