### PR TITLE
Add back prototype workflows enabled

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,3 +31,6 @@
         :ems_metrics_collector_worker_workflows: {}
       :ems_refresh_worker:
         :ems_refresh_worker_workflows: {}
+:prototype:
+  :ems_workflows:
+    :enabled: true


### PR DESCRIPTION
The UI still checks for `Settings.prototype.ems_workflows.enabled` in quite a few places.  Add this back defaulted to true for backport until we can remove it from the UI.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
