### PR TITLE
Use workflow_instance manager_ref as Execution ID

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow.rb
@@ -10,12 +10,18 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
   def run(inputs: {}, userid: "system", zone: nil, role: "automate", object: nil, execution_context: {})
     require "floe"
 
+    manager_ref = SecureRandom.uuid
+
     execution_context = execution_context.dup
+
+    execution_context["Id"]                = manager_ref
     execution_context["_manageiq_api_url"] = MiqRegion.my_region.remote_ws_url
+
     if object
       execution_context["_object_type"] = object.class.name
       execution_context["_object_id"]   = object.id
     end
+
     execution_context["_requester_userid"] = userid
     if User.current_userid == userid
       execution_context["_requester_email"] = User.current_user.email
@@ -35,7 +41,9 @@ class ManageIQ::Providers::Workflows::AutomationManager::Workflow < ManageIQ::Pr
 
       instance = children.create!(
         :manager       => manager,
+        :manager_ref   => manager_ref,
         :type          => "#{manager.class}::WorkflowInstance",
+        :name          => name,
         :run_by_userid => userid,
         :miq_task      => miq_task,
         :payload       => payload,

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_spec.rb
@@ -22,12 +22,15 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::Workflow do
 
       expect(workflow.children.count).to eq(1)
       expect(ems.configuration_scripts.count).to eq(1)
-      expect(ems.configuration_scripts.first).to have_attributes(
+
+      workflow_instance = ems.configuration_scripts.first
+      expect(workflow_instance).to have_attributes(
         :manager     => workflow.manager,
         :type        => "ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance",
+        :name        => workflow.name,
         :payload     => workflow.payload,
         :credentials => workflow.credentials,
-        :context     => {"Execution" => hash_including("Input" => inputs), "State" => {}, "StateMachine" => {}, "StateHistory" => [], "Task" => {}},
+        :context     => {"Execution" => hash_including("Id" => workflow_instance.manager_ref, "Input" => inputs), "State" => {}, "StateMachine" => {}, "StateHistory" => [], "Task" => {}},
         :output      => {},
         :status      => "pending"
       )


### PR DESCRIPTION
Set the WorkflowInstance manager_ref as the Context.Execution.Id so that we can use it to find the WorkflowInstance more easily

Related:
- [ ] https://github.com/ManageIQ/floe/pull/268
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
