### PR TITLE
Use WorkflowInstance#manager_ref and execution_id for events

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -52,7 +52,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     queue_args = args.slice(:zone, :role, :object_type, :object_id)
     zone, role, object_type, object_id = queue_args.values_at(:zone, :role, :object_type, :object_id)
 
-    ManageIQ::Providers::Workflows::Runner.runner.add_workflow(self, queue_args)
+    ManageIQ::Providers::Workflows::Runner.runner.add_workflow_instance(self, queue_args)
 
     object = object_type.constantize.find_by(:id => object_id) if object_type && object_id
     object.before_ae_starts({}) if object.present? && object.respond_to?(:before_ae_starts)
@@ -79,7 +79,7 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     end
 
     if wf.end?
-      ManageIQ::Providers::Workflows::Runner.runner.delete_workflow(self)
+      ManageIQ::Providers::Workflows::Runner.runner.delete_workflow_instance(self)
     else
       deliver_on = wf.wait_until || 1.minute.from_now.utc
       run_queue(:zone => zone, :role => role, :object => object, :deliver_on => deliver_on, :server_guid => MiqServer.my_server.guid)

--- a/manageiq-providers-workflows.gemspec
+++ b/manageiq-providers-workflows.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "floe", "~> 0.13.0", ">= 0.13.1"
+  spec.add_dependency "floe", "~> 0.14.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/factories/workflow_instance.rb
+++ b/spec/factories/workflow_instance.rb
@@ -1,3 +1,5 @@
 FactoryBot.define do
-  factory :workflows_automation_workflow_instance, :class => "ManageIQ::Providers::Workflows::AutomationManager::Workflow_instance", :parent => :workflow_instance
+  factory :workflows_automation_workflow_instance, :class => "ManageIQ::Providers::Workflows::AutomationManager::Workflow_instance", :parent => :workflow_instance do
+    manager_ref { SecureRandom.uuid }
+  end
 end

--- a/spec/lib/manageiq/providers/workflows/runner_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/runner_spec.rb
@@ -2,30 +2,30 @@ RSpec.describe ManageIQ::Providers::Workflows::Runner do
   require "floe"
 
   let(:subject)  { described_class.new }
-  let(:workflow) { FactoryBot.create(:workflows_automation_workflow_instance) }
+  let(:workflow_instance) { FactoryBot.create(:workflows_automation_workflow_instance) }
   let(:queue_args) { {:role => "automate"} }
 
   describe ".add_workflow" do
     it "adds the workflow to the workflows hash" do
-      subject.add_workflow(workflow, queue_args)
-      expect(subject.workflows.count).to eq(1)
-      expect(subject.workflows[workflow.id]).to eq([workflow, queue_args])
+      subject.add_workflow_instance(workflow_instance, queue_args)
+      expect(subject.workflow_instances.count).to eq(1)
+      expect(subject.workflow_instances[workflow_instance.manager_ref]).to eq([workflow_instance, queue_args])
     end
   end
 
   describe ".delete_workflow" do
     context "with nothing in #workflows" do
       it "doesn't throw an exception" do
-        expect(subject.delete_workflow(workflow)).to be_nil
+        expect(subject.delete_workflow_instance(workflow_instance)).to be_nil
       end
     end
 
     context "with a workflow in #workflows" do
-      before { subject.add_workflow(workflow, queue_args) }
+      before { subject.add_workflow_instance(workflow_instance, queue_args) }
 
       it "deletes the workflow from #workflows" do
-        subject.delete_workflow(workflow)
-        expect(subject.workflows).to be_empty
+        subject.delete_workflow_instance(workflow_instance)
+        expect(subject.workflow_instances).to be_empty
       end
     end
   end


### PR DESCRIPTION
Use the execution_id from the docker event to lookup the workflow_instance rather than the container_ref.  Since this is static for the life of the workflow it is a much more reliable way to make the association.

Depends on:
- [x] https://github.com/ManageIQ/floe/pull/268
- [x] Release of https://github.com/ManageIQ/floe/pull/268
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
