### PR TITLE
Remove non-existing parent factory references

### DIFF
--- a/spec/factories/workflow.rb
+++ b/spec/factories/workflow.rb
@@ -1,3 +1,3 @@
 FactoryBot.define do
-  factory :workflows_automation_workflow, :class => "ManageIQ::Providers::Workflows::AutomationManager::Workflow", :parent => :workflow
+  factory :workflows_automation_workflow, :class => "ManageIQ::Providers::Workflows::AutomationManager::Workflow"
 end

--- a/spec/factories/workflow_instance.rb
+++ b/spec/factories/workflow_instance.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
-  factory :workflows_automation_workflow_instance, :class => "ManageIQ::Providers::Workflows::AutomationManager::Workflow_instance", :parent => :workflow_instance do
+  factory :workflows_automation_workflow_instance, :class => "ManageIQ::Providers::Workflows::AutomationManager::Workflow_instance" do
+    status { "pending" }
     manager_ref { SecureRandom.uuid }
   end
 end


### PR DESCRIPTION
These factories were added: https://github.com/ManageIQ/manageiq/pull/22316
But were removed: https://github.com/ManageIQ/manageiq/pull/22503

They were basically NO-OP factories, so removing is no big deal

For some reason, older versions of FactoryBot were ok with a bad reference (probably because the klass was overridden anyway) But newer versions of FactoryBot complained
