### PR TITLE
Add object_type,_id to WorkflowInstance#run_queue

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -1,9 +1,12 @@
 class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
-  def run_queue(zone: nil, role: "automate", object: nil, deliver_on: nil, server_guid: nil)
+  def run_queue(zone: nil, role: "automate", object: nil, object_type: nil, object_id: nil, deliver_on: nil, server_guid: nil)
     args = {:zone => zone, :role => role}
     if object
       args[:object_type] = object.class.name
       args[:object_id]   = object.id
+    elsif object_type && object_id
+      args[:object_type] = object_type
+      args[:object_id]   = object_id
     end
 
     queue_opts = {

--- a/spec/lib/manageiq/providers/workflows/runner_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/runner_spec.rb
@@ -29,4 +29,58 @@ RSpec.describe ManageIQ::Providers::Workflows::Runner do
       end
     end
   end
+
+  describe "#docker_wait (private)" do
+    let(:docker_runner) { double("Floe::ContainerRunner::Docker") }
+    let(:execution_id)  { SecureRandom.uuid }
+    let(:container_ref) { SecureRandom.uuid }
+    let(:event)         { "create" }
+    let(:data)          { {"execution_id" => execution_id, "runner_context" => {"container_ref" => container_ref}} }
+
+    before do
+      allow(Floe::Runner).to receive(:for_resource).with("docker").and_return(docker_runner)
+      allow(docker_runner).to receive(:wait).and_yield(event, data)
+    end
+
+    context "with no workflows in #workflow_instances" do
+      it "doesn't queue an update for an unrecognized workflow" do
+        subject.send(:docker_wait)
+
+        expect(MiqQueue.count).to be_zero
+      end
+    end
+
+    context "with a workflow_instance registered with this runner" do
+      let(:workflow_instance) { FactoryBot.create(:workflows_automation_workflow_instance, :manager_ref => execution_id) }
+      let(:queue_args)        { {:zone => nil, :role => "automate"} }
+      before { subject.add_workflow_instance(workflow_instance, queue_args) }
+
+      it "queues a run for the workflow instance" do
+        subject.send(:docker_wait)
+
+        expect(MiqQueue.count).to eq(1)
+        expect(MiqQueue.first).to have_attributes(
+          :class_name  => "ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance",
+          :method_name => "run",
+          :args        => [{:zone => nil, :role => "automate"}],
+        )
+      end
+
+      context "with an object in queue_args" do
+        let(:service)    { FactoryBot.create(:service) }
+        let(:queue_args) { {:zone => nil, :role => "automate", :object_type => service.class.name, :object_id => service.id} }
+
+        it "queues a run for the workflow instance" do
+          subject.send(:docker_wait)
+
+          expect(MiqQueue.count).to eq(1)
+          expect(MiqQueue.first).to have_attributes(
+            :class_name  => "ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance",
+            :method_name => "run",
+            :args        => [{:zone => nil, :role => "automate", :object_type => service.class.name, :object_id => service.id}],
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix an issue where the `Workflows::Runner#docker_wait` thread queues the `workflow_instance` with `queue_args` that have `object_type`/`object_id` and not the resolved object.

`WorkflowInstance#run` looks the object up by type,id so it has the object already but `Workflows::Runner#docker_wait` only has the raw `queue_args` so it is better to allow `object_type`,`object_id` in
`WorkflowInstance#run_queue`.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
