### PR TITLE
Skip invalid workflows during sync

### DIFF
--- a/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
@@ -194,11 +194,31 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::ConfigurationS
         record = build_record
 
         expect(record.configuration_script_payloads.first).to have_attributes(
-          :name         => "hello_world.asl",
-          :description  => "hello world",
-          :payload      => a_string_including("\"Comment\": \"hello world\""),
-          :payload_type => "json"
+          :name          => "hello_world.asl",
+          :description   => "hello world",
+          :payload       => a_string_including("\"Comment\": \"hello world\""),
+          :payload_type  => "json",
+          :payload_valid => true,
+          :payload_error => nil
         )
+      end
+
+      context "with workflows with invalid json" do
+        let(:repo_dir_structure) { %w[invalid_json.asl] }
+
+        it "skips the invalid workflow file" do
+          record = build_record
+          expect(record.configuration_script_payloads).to be_empty
+        end
+      end
+
+      context "with workflows with missing states" do
+        let(:repo_dir_structure) { %w[missing_states.asl] }
+
+        it "skips the invalid workflow file" do
+          record = build_record
+          expect(record.configuration_script_payloads).to be_empty
+        end
       end
 
       context "with a nested dir" do

--- a/spec/support/fake_workflows_repo.rb
+++ b/spec/support/fake_workflows_repo.rb
@@ -12,10 +12,21 @@ module Spec
         dummy_workflow_data_for(full_path) if full_path.fnmatch?("**/*.asl", File::FNM_EXTGLOB)
       end
 
-      def dummy_workflow_data_for(_filename)
-        <<~WORKFLOW_DATA
-          {"Comment": "hello world", "States": {"Start": {"Type": "Succeed"}}, "StartAt": "Start"}
-        WORKFLOW_DATA
+      def dummy_workflow_data_for(filename)
+        case filename.to_s
+        when /invalid_json.asl$/
+          <<~WORKFLOW_DATA
+            {"Invalid Json"
+          WORKFLOW_DATA
+        when /missing_states.asl$/
+          <<~WORKFLOW_DATA
+            {"Comment": "Missing States"}
+          WORKFLOW_DATA
+        else
+          <<~WORKFLOW_DATA
+            {"Comment": "hello world", "States": {"Start": {"Type": "Succeed"}}, "StartAt": "Start"}
+          WORKFLOW_DATA
+        end
       end
     end
   end


### PR DESCRIPTION
When syncing a repository and creating workflows check if the payload is valid and if it isn't log a (hopefully) helpful error message.

This is based on https://github.com/ManageIQ/manageiq-providers-workflows/pull/59 but instead of requiring a new column this will log the error and skip any invalid workflows.

There was also an issue with the not-implemented states raising an exception that wasn't a `Floe::InvalidWorkflowError` which would have skipped this rescue.

Example log message:
`WARN -- evm: MIQ(ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSource#create_workflow_from_payload) Invalid ASL file [missing_states.asl]: State Machine does not have required field "States"`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
