### PR TITLE
Delete unused blacklisted_event_names

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 :ems:
   :ems_workflows:
-    :blacklisted_event_names: []
     :event_handling:
       :event_groups:
     :runner_options:


### PR DESCRIPTION
The Workflows::AutomationManager doesn't have an event_catcher and thus doesn't need a blacklisted_event_names setting

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
