### PR TITLE
Set logger for each workflow run

### DIFF
--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -244,7 +244,8 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
         end
 
         it "passes the resolved credential to the runner" do
-          expect(Floe::Workflow).to receive(:new).with(payload.to_json, context.to_h, {"username" => "my-user", "password" => "shhhh!"}).and_call_original
+          # second argument is a new Context that was created with context.to_h
+          expect(Floe::Workflow).to receive(:new).with(payload.to_json, anything, {"username" => "my-user", "password" => "shhhh!"}).and_call_original
           workflow_instance.run
         end
 


### PR DESCRIPTION
Blocked by:
- [x] https://github.com/ManageIQ/manageiq/pull/23426

Creates RequestLog records for each log entries
This way the messages will show up in The log entries on the Request screen This creates the same.

Did feel like I reinvented the wheel with the log proxy, but it seemed the simplest way.
I lifted `request_log` - with only trivial changes

<img width="908" alt="SCR-20250401-qjhv" src="https://github.com/user-attachments/assets/f0b98b7f-9481-45f8-b80d-ad8f25fedd64" />
