### PR TITLE
Fix Logger error when called from service

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -137,6 +137,9 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
 
   def create_logger(object)
     log_target_id = object.miq_request_id if object.respond_to?(:miq_request_id)
-    log_target_id ? Floe.logger.wrap(Vmdb::Loggers::RequestLogger.new(:resource_id => log_target_id)) : Floe.logger
+    return Floe.logger if log_target_id.nil?
+
+    request_logger = Vmdb::Loggers::RequestLogger.new(:resource_id => log_target_id)
+    ManageIQ::Loggers::Base.wrap(Floe.logger, request_logger)
   end
 end


### PR DESCRIPTION
When called from a MiqRequest object we use a `Vmdb::Loggers::RequestLogger` so that floe logs can be seen in the UI easily.  If `Floe.logger` is already a `BroadcastLogger` then `Floe.logger.wrap` isn't calling `ManageIQ::Loggers::Base#wrap` it is actually calling `ActiveSupport::BroadcastLogger#method_missing` which does `loggers.map { |logger| logger.send(name, ...) }` and results in an array being returned.

This array is then used as the `workflow.context.logger` so when we try to log to it we get `undefined method info for Array`

Introduced by https://github.com/ManageIQ/manageiq-providers-workflows/pull/128
Fixes https://github.com/ManageIQ/manageiq-providers-workflows/issues/134
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
