### PR TITLE
Use workflow credentials interface

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -60,9 +60,9 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
     object = object_type.constantize.find_by(:id => object_id) if object_type && object_id
     object.before_ae_starts({}) if object.present? && object.respond_to?(:before_ae_starts)
 
-    context_obj = Floe::Workflow::Context.new(context, :logger => create_logger(object))
+    context_obj = Floe::Workflow::Context.new(context, :credentials => resolved_credentials, :logger => create_logger(object))
 
-    wf = Floe::Workflow.new(payload, context_obj, resolved_credentials)
+    wf = Floe::Workflow.new(payload, context_obj)
     wf.run_nonblock
     update_credentials!(wf.credentials)
 

--- a/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/workflow_instance_spec.rb
@@ -244,8 +244,12 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstan
         end
 
         it "passes the resolved credential to the runner" do
-          # second argument is a new Context that was created with context.to_h
-          expect(Floe::Workflow).to receive(:new).with(payload.to_json, anything, {"username" => "my-user", "password" => "shhhh!"}).and_call_original
+          expect(workflow_instance.send(:resolved_credentials)).to eq({"username" => "my-user", "password" => "shhhh!"})
+          expect(Floe::Workflow).to receive(:new) do |pay_arg, context_arg|
+            expect(pay_arg).to eq(payload.to_json)
+            expect(context_arg.credentials).to eq({"username" => "my-user", "password" => "shhhh!"})
+          end.and_call_original
+
           workflow_instance.run
         end
 


### PR DESCRIPTION
depends:
- add interface to floe and release floe


This removes the knowledge of the context constructor and the workflow constructor It also standardizes on passing around ruby hashes and not json strings

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
