### PR TITLE
[WIP] Update Workflows BuiltinRunner to inherit from Floe

### DIFF
--- a/lib/manageiq/providers/workflows/builtin_methods.rb
+++ b/lib/manageiq/providers/workflows/builtin_methods.rb
@@ -49,17 +49,17 @@ module ManageIQ
 
           if playbook_id
             playbook = ::ConfigurationScriptPayload.find_by(:id => playbook_id)
-            return BuiltinRunner.error!({}, :cause => "Unable to find Playbook: Id: [#{playbook_id}] Repository: [#{repository.name}]") if playbook.nil?
+            return ::Floe::BuiltinRunner.error!({}, :cause => "Unable to find Playbook: Id: [#{playbook_id}] Repository: [#{repository.name}]") if playbook.nil?
           else
             repository = ::ConfigurationScriptSource.find_by(:scm_url => repository_url, :scm_branch => repository_branch)
-            return BuiltinRunner.error!({}, :cause => "Unable to find Repository: URL: [#{repository_url}] Branch: [#{repository_branch}]") if repository.nil?
+            return ::Floe::BuiltinRunner.error!({}, :cause => "Unable to find Repository: URL: [#{repository_url}] Branch: [#{repository_branch}]") if repository.nil?
 
             playbook = ::ConfigurationScriptPayload.find_by(:configuration_script_source => repository, :name => playbook_name)
-            return BuiltinRunner.error!({}, :cause => "Unable to find Playbook: Name: [#{playbook_name}] Repository: [#{repository.name}]") if playbook.nil?
+            return ::Floe::BuiltinRunner.error!({}, :cause => "Unable to find Playbook: Name: [#{playbook_name}] Repository: [#{repository.name}]") if playbook.nil?
           end
 
           unless playbook.class <= ::ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook
-            return BuiltinRunner.error!({}, :cause => "Invalid playbook: ID: [#{playbook.id}] Type: [#{playbook.type}]")
+            return ::Floe::BuiltinRunner.error!({}, :cause => "Invalid playbook: ID: [#{playbook.id}] Type: [#{playbook.type}]")
           end
 
           job = playbook.run(vars)
@@ -73,12 +73,12 @@ module ManageIQ
 
         def self.provision_execute(_params, _secrets, context)
           object_type, object_id = context.execution.values_at("_object_type", "_object_id")
-          return BuiltinRunner.error!({}, :cause => "Missing MiqRequestTask type") if object_type.nil?
-          return BuiltinRunner.error!({}, :cause => "Missing MiqRequestTask id")   if object_id.nil?
+          return ::Floe::BuiltinRunner.error!({}, :cause => "Missing MiqRequestTask type") if object_type.nil?
+          return ::Floe::BuiltinRunner.error!({}, :cause => "Missing MiqRequestTask id")   if object_id.nil?
 
           miq_request_task = ::MiqRequestTask.find_by(:id => object_id.to_i)
-          return BuiltinRunner.error!({}, :cause => "Unable to find MiqReqeustTask id: [#{object_id}]")                        if miq_request_task.nil?
-          return BuiltinRunner.error!({}, :cause => "Calling provision_execute on non-provisioning request: [#{object_type}]") unless miq_request_task.class < ::MiqProvisionTask
+          return ::Floe::BuiltinRunner.error!({}, :cause => "Unable to find MiqReqeustTask id: [#{object_id}]")                        if miq_request_task.nil?
+          return ::Floe::BuiltinRunner.error!({}, :cause => "Calling provision_execute on non-provisioning request: [#{object_type}]") unless miq_request_task.class < ::MiqProvisionTask
 
           new_options = context.input.symbolize_keys.slice(*miq_request_task.options.keys)
           miq_request_task.options_will_change!
@@ -120,7 +120,7 @@ module ManageIQ
 
         private_class_method def self.miq_task_status!(runner_context)
           miq_task = ::MiqTask.find_by(:id => runner_context["miq_task_id"])
-          return BuiltinRunner.error!(runner_context, :cause => "Unable to find MiqTask id: [#{runner_context["miq_task_id"]}]") if miq_task.nil?
+          return ::Floe::BuiltinRunner.error!(runner_context, :cause => "Unable to find MiqTask id: [#{runner_context["miq_task_id"]}]") if miq_task.nil?
 
           runner_context["running"] = miq_task.state != ::MiqTask::STATE_FINISHED
 
@@ -129,7 +129,7 @@ module ManageIQ
             if runner_context["success"]
               runner_context["output"] = miq_task.message
             else
-              BuiltinRunner.error!(runner_context, :cause => miq_task.message)
+              Floe::BuiltinRunner.error!(runner_context, :cause => miq_task.message)
             end
           end
 
@@ -142,15 +142,15 @@ module ManageIQ
           case miq_request_task&.statemachine_task_status
           when nil
             reason = "Unable to find MiqRequestTask id: [#{runner_context["miq_request_task_id"]}]"
-            BuiltinRunner.error!(runner_context, :cause => reason)
+            Floe::BuiltinRunner.error!(runner_context, :cause => reason)
           when "error"
             reason = miq_request_task.message&.sub(/^Error: /, "")
-            BuiltinRunner.error!(runner_context, :cause => reason)
+            Floe::BuiltinRunner.error!(runner_context, :cause => reason)
           when "retry"
             runner_context["running"] = true
             runner_context
           when "ok"
-            BuiltinRunner.success!(runner_context, :output => {"Result" => miq_request_task.completed_state})
+            ::Floe::BuiltinRunner.success!(runner_context, :output => {"Result" => miq_request_task.completed_state})
           end
         end
       end

--- a/lib/manageiq/providers/workflows/builtin_runner.rb
+++ b/lib/manageiq/providers/workflows/builtin_runner.rb
@@ -3,23 +3,9 @@ module ManageIQ
     module Workflows
       require "floe"
 
-      class BuiltinRunner < Floe::Runner
+      class BuiltinRunner < Floe::BuiltinRunner::Runner
         SCHEME = "manageiq".freeze
         SCHEME_PREFIX = "#{SCHEME}://".freeze
-
-        class << self
-          def error!(runner_context = {}, cause:, error: "States.TaskFailed")
-            runner_context.merge!(
-              "running" => false, "success" => false, "output" => {"Error" => error, "Cause" => cause}
-            )
-          end
-
-          def success!(runner_context = {}, output:)
-            runner_context.merge!(
-              "running" => false, "success" => true, "output" => output
-            )
-          end
-        end
 
         def run_async!(resource, params, secrets, context)
           raise ArgumentError, "Invalid resource" unless resource&.start_with?(SCHEME_PREFIX)
@@ -31,42 +17,12 @@ module ManageIQ
             method_result = BuiltinMethods.public_send(method_name, params, secrets, context)
             method_result.merge(runner_context)
           rescue NoMethodError
-            self.class.error!(runner_context, :cause => "undefined method [#{method_name}]")
+            Floe::BuiltinRunner.error!(runner_context, :cause => "undefined method [#{method_name}]")
           rescue => err
-            self.class.error!(runner_context, :cause => err.to_s)
+            Floe::BuiltinRunner.error!(runner_context, :cause => err.to_s)
           ensure
             cleanup(runner_context)
           end
-        end
-
-        def cleanup(runner_context)
-          method_name = runner_context["method"]
-          raise ArgumentError if method_name.nil?
-
-          cleanup_method = "#{method_name}_cleanup"
-          return unless BuiltinMethods.respond_to?(cleanup_method, true)
-
-          BuiltinMethods.send(cleanup_method, runner_context)
-        end
-
-        def status!(runner_context)
-          method_name = runner_context["method"]
-          raise ArgumentError if method_name.nil?
-          return if runner_context["running"] == false
-
-          BuiltinMethods.send("#{method_name}_status!", runner_context)
-        end
-
-        def running?(runner_context)
-          runner_context["running"]
-        end
-
-        def success?(runner_context)
-          runner_context["success"]
-        end
-
-        def output(runner_context)
-          runner_context["output"]
         end
       end
     end


### PR DESCRIPTION
Inherit Workflows::BuiltinRunner on Floe's BuiltinRunner.

This allows for sharing the builtin_runner methods cleanup, status, running?, success? and also allows for us to "wrap" floe:// builtin methods like `floe://http` with `manageiq://http`.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
