### PR TITLE
Wrap Floe builtin methods in `manageiq://`

### DIFF
--- a/lib/manageiq/providers/workflows/builtin_methods.rb
+++ b/lib/manageiq/providers/workflows/builtin_methods.rb
@@ -1,7 +1,7 @@
 module ManageIQ
   module Providers
     module Workflows
-      class BuiltinMethods < BasicObject
+      class BuiltinMethods < Floe::BuiltinRunner::Methods
         def self.email(params, _secrets, context)
           options = params.slice("To", "From", "Subject", "Cc", "Bcc", "Body", "Attachment").transform_keys { |k| k.downcase.to_sym }
           options[:from] ||= ::Settings.smtp.from

--- a/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
@@ -4,6 +4,29 @@ RSpec.describe ManageIQ::Providers::Workflows::BuiltinMethods do
   let(:ctx) { Floe::Workflow::Context.new }
   let(:secrets) { {} }
 
+  describe ".http" do
+    let(:faraday_stub) { double("Faraday::Connection") }
+
+    before do
+      require "faraday"
+      allow(Faraday).to receive(:new).and_return(faraday_stub)
+      allow(faraday_stub).to receive(:response).with(:follow_redirects)
+    end
+
+    it "performs the get" do
+      expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 200, :body => "{}"))
+
+      params = {"Method" => "GET", "Url" => "http://localhost"}
+      runner_context = described_class.http(params, secrets, ctx)
+      expect(runner_context)
+        .to include(
+          "running" => false,
+          "success" => true,
+          "output"  => {"Body" => "{}", "Headers" => nil, "Status" => 200}
+        )
+    end
+  end
+
   describe ".email" do
     let(:params) { {"To" => "foo@bar.com", "From" => "baz@bar.com"} }
 


### PR DESCRIPTION
Allow calling `floe://` builtin methods like `floe://http` from the manageiq builtin runner e.g. `manageiq://http`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
