### PR TITLE
Include info about the MiqRequestTask in state output

### DIFF
--- a/lib/manageiq/providers/workflows/builtin_methods.rb
+++ b/lib/manageiq/providers/workflows/builtin_methods.rb
@@ -9,7 +9,7 @@ module ManageIQ
             path         = params.delete("Path") || "/"
             api_base_url = context.execution["_manageiq_api_url"]
 
-            params["Url"] ||= ::URI.join(api_base_url, path).to_s
+            params["Url"] ||= ::File.join(api_base_url, path).to_s
           end
 
           params["Options"] ||= {}
@@ -92,7 +92,7 @@ module ManageIQ
           miq_request_task.save!
           miq_request_task.execute_queue
 
-          {"miq_request_task_id" => miq_request_task.id}
+          {"miq_request_task_id" => miq_request_task.id, "_manageiq_api_url" => context.execution&.dig("_manageiq_api_url")}
         end
 
         private_class_method def self.provision_execute_status!(runner_context)
@@ -115,7 +115,7 @@ module ManageIQ
           miq_request_task.save!
           miq_request_task.execute_queue
 
-          {"miq_request_task_id" => miq_request_task.id}
+          {"miq_request_task_id" => miq_request_task.id, "_manageiq_api_url" => context.execution&.dig("_manageiq_api_url")}
         end
 
         private_class_method def self.retire_execute_status!(runner_context)
@@ -156,8 +156,27 @@ module ManageIQ
             runner_context["running"] = true
             runner_context
           when "ok"
-            BuiltinRunner.success!(runner_context, :output => {"Result" => miq_request_task.completed_state})
+            BuiltinRunner.success!(runner_context, :output => miq_request_task_result(runner_context, miq_request_task))
           end
+        end
+
+        private_class_method def self.miq_request_task_result(runner_context, miq_request_task)
+          api_base_url = ::File.join(runner_context["_manageiq_api_url"], "api") if runner_context["_manageiq_api_url"]
+
+          result         = {"id" => miq_request_task.id, "state" => miq_request_task.state, "status" => miq_request_task.status}
+          result["href"] = ::File.join(api_base_url, miq_request_task.href_slug) if api_base_url
+
+          if miq_request_task.source
+            result["source"]         = {"id" => miq_request_task.source_id}
+            result["source"]["href"] = ::File.join(api_base_url, miq_request_task.source.href_slug) if api_base_url
+          end
+
+          if miq_request_task.destination
+            result["destination"]         = {"id" => miq_request_task.destination_id}
+            result["destination"]["href"] = ::File.join(api_base_url, miq_request_task.destination.href_slug) if api_base_url
+          end
+
+          result
         end
       end
     end

--- a/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
@@ -307,23 +307,39 @@ RSpec.describe ManageIQ::Providers::Workflows::BuiltinMethods do
       expect(runner_context).to include("running" => false, "success" => false, "output" => failed_task_status(/Calling provision_execute on non-provisioning request/))
     end
 
-    it "updates task options" do
-      task_options = {
-        :src_vm_id => FactoryBot.create(:vm_vmware, :ext_management_system => FactoryBot.create(:ems_vmware_with_authentication)).id,
-        :param1    => 5,
-        :param2    => 4,
-        :param3    => 3
-      }
-      request = FactoryBot.create(:miq_provision_request, :with_approval)
-      request.miq_approvals.update_all(:state => "approved")
-      task = FactoryBot.create(:miq_provision_vmware, :clone_to_vm, :options => task_options, :miq_request => request)
-      floe_context = create_floe_context(task, :input => {:param1 => 1, :param2 => 2})
-      runner_context = described_class.provision_execute(params, secrets, floe_context)
-      task.reload
+    context "with a miq_provision_task" do
+      let(:ems)     { FactoryBot.create(:ems_vmware_with_authentication) }
+      let(:request) { FactoryBot.create(:miq_provision_request, :with_approval).tap { |r| r.miq_approvals.update_all(:state => "approved") } }
+      let(:source)  { FactoryBot.create(:template_vmware, :ext_management_system => ems) }
+      let(:dest)    { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+      let(:options) { {:src_vm_id => source.id, :vm_name => "myvm", :memory_mb => 1_024} }
+      let(:task)    { FactoryBot.create(:miq_provision_vmware, :clone_to_vm, :options => options, :miq_request => request) }
 
-      expect(runner_context["miq_request_task_id"]).to eq(task.id)
-      expect(task.options).to include(:param1 => 1, :param2 => 2, :param3 => 3)
-      expect(task.options.key?(:param4)).to eq(false)
+      it "updates task options" do
+        floe_context = create_floe_context(task, :input => {:vm_name => "myvm2", :cpu_sockets => 2})
+        runner_context = described_class.provision_execute(params, secrets, floe_context)
+        task.reload
+
+        expect(runner_context["miq_request_task_id"]).to eq(task.id)
+        expect(task.options).to include(:vm_name => "myvm2", :memory_mb => 1_024)
+        expect(task.options.keys).not_to include(:cpu_sockets)
+      end
+
+      it "returns the miq_request_task info" do
+        floe_context = create_floe_context(task)
+        runner_context = described_class.provision_execute(params, secrets, floe_context)
+        task.update!(:state => "provisioned", :status => "Ok", :destination => dest)
+        described_class.send(:provision_execute_status!, runner_context)
+
+        expect(runner_context["output"]).to include(
+          "id"          => task.id,
+          "href"        => "http://localhost:3000/api/request_tasks/#{task.id}",
+          "state"       => "provisioned",
+          "status"      => "Ok",
+          "source"      => {"id" => source.id, "href" => "http://localhost:3000/api/templates/#{source.id}"},
+          "destination" => {"id" => dest.id,   "href" => "http://localhost:3000/api/vms/#{dest.id}"}
+        )
+      end
     end
   end
 
@@ -367,7 +383,7 @@ RSpec.describe ManageIQ::Providers::Workflows::BuiltinMethods do
   end
 
   def create_floe_context(object = nil, execution: nil, input: {})
-    execution ||= {"_object_id" => object&.id, "_object_type" => object&.class}.compact
+    execution ||= {"_object_id" => object&.id, "_object_type" => object&.class, "_manageiq_api_url" => "http://localhost:3000"}.compact
 
     Floe::Workflow::Context.new({"Execution" => execution}, :input => input.to_json).tap { |ctx| ctx.state["Input"] = input }
   end


### PR DESCRIPTION
Include the ID, href, state, status, and source/destination information in the state output.

This will help further states by including what is needed directly or by retrieving additional info from the API.

Example from a `manageiq://provision_execute` state:
```
    {"id"=>122,
     "href"=>"http://localhost:3000/api/request_tasks/122",
     "state"=>"provisioned",
     "source"=>{"id"=>800, "href"=>"http://localhost:3000/api/templates/800"},
     "status"=>"Ok",
     "destination"=>{"id"=>800, "href"=>"http://localhost:3000/api/vms/51"}}
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
