### PR TITLE
Add Username/Password options to `manageiq://api`

### DIFF
--- a/lib/manageiq/providers/workflows/builtin_methods.rb
+++ b/lib/manageiq/providers/workflows/builtin_methods.rb
@@ -18,6 +18,10 @@ module ManageIQ
           params["Headers"] ||= {}
           params["Headers"]["ContentType"] ||= "application/json"
 
+          if secrets["username"] && secrets["password"]
+            params["Headers"]["Authorization"] = "Basic #{::Base64.strict_encode64(secrets.values_at("username", "password").join(":"))}"
+          end
+
           http(params, secrets, context)
         end
 

--- a/lib/manageiq/providers/workflows/builtin_methods.rb
+++ b/lib/manageiq/providers/workflows/builtin_methods.rb
@@ -18,7 +18,9 @@ module ManageIQ
           params["Headers"] ||= {}
           params["Headers"]["ContentType"] ||= "application/json"
 
-          if secrets["username"] && secrets["password"]
+          if secrets["bearer_token"]
+            params["Headers"]["Authorization"] = "Bearer #{secrets["bearer_token"]}"
+          elsif secrets["username"] && secrets["password"]
             params["Headers"]["Authorization"] = "Basic #{::Base64.strict_encode64(secrets.values_at("username", "password").join(":"))}"
           end
 

--- a/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
+++ b/spec/lib/manageiq/providers/workflows/builtin_methods_spec.rb
@@ -54,6 +54,78 @@ RSpec.describe ManageIQ::Providers::Workflows::BuiltinMethods do
           "output"  => {"Cause" => "You must provide either Url or Path, not both", "Error" => "States.TaskFailed"}
         )
     end
+
+    it "adds a Basic authorization header if username and password is passed in Credentials" do
+      expect(Faraday)
+        .to receive(:new)
+        .with(
+          hash_including(
+            :url     => "http://localhost:3000/api/auth",
+            :headers => hash_including("Authorization" => "Basic #{Base64.strict_encode64("admin:password")}")
+          )
+        )
+        .and_return(faraday_stub)
+      expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 200, :body => "{}"))
+
+      params  = {"Path" => "/api/auth"}
+      secrets = {"username" => "admin", "password" => "password"}
+
+      runner_context = described_class.api(params, secrets, ctx)
+      expect(runner_context)
+        .to include(
+          "running" => false,
+          "success" => true,
+          "output"  => {"Body" => "{}", "Headers" => nil, "Status" => 200}
+        )
+    end
+
+    it "adds a Bearer authorization header if bearer_token is passed in Credentials" do
+      expect(Faraday)
+        .to receive(:new)
+        .with(
+          hash_including(
+            :url     => "http://localhost:3000/api/auth",
+            :headers => hash_including("Authorization" => "Bearer abcdefg")
+          )
+        )
+        .and_return(faraday_stub)
+      expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 200, :body => "{}"))
+
+      params  = {"Path" => "/api/auth"}
+      secrets = {"bearer_token" => "abcdefg"}
+
+      runner_context = described_class.api(params, secrets, ctx)
+      expect(runner_context)
+        .to include(
+          "running" => false,
+          "success" => true,
+          "output"  => {"Body" => "{}", "Headers" => nil, "Status" => 200}
+        )
+    end
+
+    it "Bearer token takes precedence if username/password also passed" do
+      expect(Faraday)
+        .to receive(:new)
+        .with(
+          hash_including(
+            :url     => "http://localhost:3000/api/auth",
+            :headers => hash_including("Authorization" => "Bearer abcdefg")
+          )
+        )
+        .and_return(faraday_stub)
+      expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 200, :body => "{}"))
+
+      params  = {"Path" => "/api/auth"}
+      secrets = {"username" => "admin", "password" => "password", "bearer_token" => "abcdefg"}
+
+      runner_context = described_class.api(params, secrets, ctx)
+      expect(runner_context)
+        .to include(
+          "running" => false,
+          "success" => true,
+          "output"  => {"Body" => "{}", "Headers" => nil, "Status" => 200}
+        )
+    end
   end
 
   describe ".http" do


### PR DESCRIPTION
Not sure we want to do this, but I had this locally and it simplified the step of having to login and set the token in credentials before using the API and figured I'd throw it up for comment
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
