### PR TITLE
Fix JSON parse exception message expectation

### DIFF
--- a/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe ManageIQ::Providers::Workflows::AutomationManager::ConfigurationS
             :payload       => "{\"Invalid Json\"\n",
             :payload_type  => "json",
             :payload_valid => false,
-            :payload_error => "expected ':' after object key at line 1 column 1"
+            :payload_error => a_string_matching(/expected ':' after object key/)
           )
         end
       end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-providers-workflows/actions/runs/28138959660/job/83331884882#step:7:117

```
Failures:

  1) ManageIQ::Providers::Workflows::AutomationManager::ConfigurationScriptSource with a local repo #sync with workflows with invalid json sets the payload_valid and payload_error attributes
     Failure/Error:
       expect(record.configuration_script_payloads.first).to have_attributes(
         :name          => "invalid_json.asl",
         :payload       => "{\"Invalid Json\"\n",
         :payload_type  => "json",
         :payload_valid => false,
         :payload_error => "expected ':' after object key at line 1 column 1"
       )

       expected #<ManageIQ::Providers::Workflows::AutomationManager::Workflow id: 70000000000016, manager_id: 7000000...sk_id: nil, payload_valid: false, payload_error: "expected ':' after object key at line 2 column 1"> to have attributes {:name => "invalid_json.asl", :payload => "{\"Invalid Json\"\n", :payload_error => "expected ':' after object key at line 1 column 1", :payload_type => "json", :payload_valid => false} but had attributes {:name => "invalid_json.asl", :payload => "{\"Invalid Json\"\n", :payload_error => "expected ':' after object key at line 2 column 1", :payload_type => "json", :payload_valid => false}
       Diff:
       @@ -1,5 +1,5 @@
        :name => "invalid_json.asl",
        :payload => "{\"Invalid Json\"\n",
       -:payload_error => "expected ':' after object key at line 1 column 1",
       +:payload_error => "expected ':' after object key at line 2 column 1",
        :payload_type => "json",
        :payload_valid => false,
     # ./spec/models/manageiq/providers/workflows/automation_manager/configuration_script_source_spec.rb:211:in `block (5 levels) in <top (required)>'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
