### PR TITLE
Fix invalid resource servicenow in workflow_instance

### DIFF
--- a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
+++ b/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb
@@ -52,6 +52,9 @@ class ManageIQ::Providers::Workflows::AutomationManager::WorkflowInstance < Mana
   end
 
   def run(args = {})
+    require "floe"
+    require "floe/servicenow"
+
     queue_args = args.slice(:zone, :role, :object_type, :object_id)
     zone, role, object_type, object_id = queue_args.values_at(:zone, :role, :object_type, :object_id)
 


### PR DESCRIPTION
The require bringing the servicenow gem in was in the `Workflow#run` method, but on an appliance that is run from a `GenericWorker` and the `WorkflowInstance#run` is in the `AutomationWorker` so it wasn't required in that process space.

```
ERROR -- evm: [Floe::InvalidWorkflowError]: States.ListTables field "Resource" value "servicenow://table/list_tables" Invalid resource scheme [servicenow]
ERROR -- evm: gems/floe-0.20.0/lib/floe/validation_mixin.rb:42:in `invalid_field_error!'
gems/floe-0.20.0/lib/floe/validation_mixin.rb:18:in `invalid_field_error!'
...
gems/floe-0.20.0/lib/floe/workflow.rb:94:in `initialize'
gems/manageiq-providers-workflows-f47171bc306a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb:65:in `new'
gems/manageiq-providers-workflows-f47171bc306a/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb:65:in `run'
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
